### PR TITLE
add syntax folding

### DIFF
--- a/syntax/icalendar.vim
+++ b/syntax/icalendar.vim
@@ -36,6 +36,13 @@ syn keyword	icalSetValue	NEEDS-ACTION ACCEPTED DECLINED IN-PROGRESS
 syn keyword	icalSetValue	PRIVATE PUBLIC PUBLISH GREGORIAN DISPLAY
 syn match	icalSetValue	/:COMPLETED$/
 
+" to enable syntax folding, add to your vimrc:
+" augroup iCalendarFolding
+"   autocmd!
+"   autocmd FileType icalendar setlocal foldmethod=syntax
+" augroup END
+syntax region icalObject start="^BEGIN:\z([A-Z]\+\)$" end="^END:\z1$" fold transparent keepend extend
+
 " Types: PreProc Keyword Type String Comment Special
 IcalHiLink	icalProperty	PreProc
 IcalHiLink	icalObject	Label


### PR DESCRIPTION
There is also  @Freed-Wu 's https://github.com/Freed-Wu/icalendar-fold.vim/blob/master/autoload/icalendar/fold.vim using expr folding; as this file already adds syntax highlighting, it seemed a natural choice of folding method.

See also https://github.com/chutzpah/icalendar.vim/pull/1